### PR TITLE
Add binder, test distributions

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -5,7 +5,7 @@ channels:
   - nodefaults
 
 dependencies:
-  - jupyter-packaging
+  - jupyter-packaging >=0.7.9,<0.8
   - jupyterlab >=3,<4
   - nodejs >=12,!=13.*,<15
   - pip

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,13 +1,12 @@
-# This is a micromamba configuration file
-
 name: default
 
 channels:
   - conda-forge
+  - nodefaults
 
 dependencies:
   - python
   - pip
-  - nodejs
-  - jupyterlab=3
+  - nodejs >=12,!=13.*,<15
+  - jupyterlab >=3,<4
   - jupyter-packaging

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -5,8 +5,10 @@ channels:
   - nodefaults
 
 dependencies:
-  - python
-  - pip
-  - nodejs >=12,!=13.*,<15
-  - jupyterlab >=3,<4
   - jupyter-packaging
+  - jupyterlab >=3,<4
+  - nodejs >=12,!=13.*,<15
+  - pip
+  - python
+  - twine
+  - wheel

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+python -m pip install -e . --ignore-installed --no-deps
+jupyter labextension list

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,10 +102,31 @@ jobs:
         name: jupyterlab_robotmode dist ${{ github.run_number }}
         path: ./dist
 
-    - name: Install Dependencies
+    - name: Install Setup Dependencies
       run: |
         set -eux
         ${{ matrix.py-cmd }} -m pip install --upgrade pip wheel setuptools
+
+    - name: Get Python Cache Location and Distribution
+      id: cache-pip
+      shell: bash -l {0}
+      run: |
+        set -eux
+        echo "::set-output name=dir::$(${{ matrix.py-cmd }} -m pip cache dir)"
+
+    - name: Cache Python Dependencies
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.cache-pip.outputs.dir }}
+        key: |
+          ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-install-${{ matrix.python-version }}-${{ matrix.lab-version }}
+        restore-keys: |
+          ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-install-${{ matrix.python-version }}-
+          ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
+
+    - name: Install Dependencies
+      run: |
+        set -eux
         ${{ matrix.py-cmd }} -m pip install 'jupyterlab==${{ matrix.lab-version }}.*'
 
     - name: Install Distribution
@@ -113,19 +134,6 @@ jobs:
         set -eux
         cd dist
         ${{ matrix.py-cmd }} -m pip install -v ${{ matrix.dist }}
-
-    - name: Get sys.prefix
-      id: sys-prefix
-      shell: bash -l {0}
-      run: |
-        set -eux
-        echo "::set-output name=path::$(${{ matrix.py-cmd }} -c 'import sys; print(sys.prefix)')"
-
-    - name: Check installation files
-      run: |
-        set -eux
-        test -d ${{ steps.sys-prefix.outputs.path }}/share/jupyter/labextensions/@marketsquare/jupyterlab_robotmode
-        test -f ${{ steps.sys-prefix.outputs.path }}/share/jupyter/labextensions/@marketsquare/jupyterlab_robotmode/package.json
 
     - name: Check labextension
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,12 @@ jobs:
           dist: jupyterlab_robotmode*.tar.gz
         - python-version: 3.9
           dist: jupyterlab_robotmode*.whl
+        - os: windows
+          py-cmd: python
+        - os: macos
+          py-cmd: python3
+        - os: ubuntu
+          py-cmd: python
 
     steps:
     - name: Install Python
@@ -99,21 +105,21 @@ jobs:
     - name: Install Dependencies
       run: |
         set -eux
-        pip install --upgrade pip wheel setuptools
-        pip install 'jupyterlab==${{ matrix.lab-version }}.*'
+        ${{ matrix.py-cmd }} -m pip install --upgrade pip wheel setuptools
+        ${{ matrix.py-cmd }} -m pip install 'jupyterlab==${{ matrix.lab-version }}.*'
 
     - name: Install Distribution
       run: |
         set -eux
         cd dist
-        pip install -v ${{ matrix.dist }}
+        ${{ matrix.py-cmd }} -m pip install -v ${{ matrix.dist }}
 
     - name: Get sys.prefix
       id: sys-prefix
       shell: bash -l {0}
       run: |
         set -eux
-        echo "::set-output name=path::$(python -c 'import sys; print(sys.prefix)')"
+        echo "::set-output name=path::$(${{ matrix.py-cmd }} -c 'import sys; print(sys.prefix)')"
 
     - name: Check installation files
       run: |
@@ -124,5 +130,5 @@ jobs:
     - name: Check labextension
       run: |
         set -eux
-        jupyter labextension list
-        jupyter labextension list 2>&1 | grep -ie "@marketsquare/jupyterlab_robotmode.*enabled.*ok" -
+        ${{ matrix.py-cmd }} -m jupyter labextension list
+        ${{ matrix.py-cmd }} -m jupyter labextension list 2>&1 | grep -ie "@marketsquare/jupyterlab_robotmode.*enabled.*ok" -

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,4 +117,5 @@ jobs:
     - name: Check labextension
       run: |
         set -eux
+        jupyter labextension list
         jupyter labextension list 2>&1 | grep -ie "@marketsquare/jupyterlab_robotmode.*enabled.*ok" -

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
       run: twine check dist/*
 
     - name: Build NPM package
-      run: cd dist && npm pack ..
+      run: cd dist && npm pack --ignore-scripts ..
 
     - name: Hash Distributions
       run: cd dist && sha256sum * | tee SHA256SUMS

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,7 @@ jobs:
       matrix:
         os: [ubuntu, windows, macos]
         python-version: [3.6, 3.9]
+        lab-version: [3]
         include:
         - python-version: 3.6
           dist: jupyterlab_robotmode*.tar.gz
@@ -94,6 +95,12 @@ jobs:
       with:
         name: jupyterlab_robotmode dist ${{ github.run_number }}
         path: ./dist
+
+    - name: Install Dependencies
+      run: |
+        set -eux
+        pip install --upgrade pip wheel setuptools
+        pip install 'jupyterlab==${{ matrix.lab-version }}.*'
 
     - name: Install Distribution
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@master  # TODO: revert to @v2 when miniforge available
       with:
         environment-file: ${{ env.BINDER_ENV }}
-        miniconda-variant: Mambaforge
+        miniforge-variant: Mambaforge
         use-mamba: true
         use-only-tar-bz2: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ env:
   BINDER_ENV: .binder/environment.yml
 
 jobs:
-  run:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -43,7 +43,26 @@ jobs:
       with:
         environment-file: ${{ env.BINDER_ENV }}
         miniconda-variant: Mambaforge
+        use-mamba: true
         use-only-tar-bz2: true
+
+    - name: Build Python packages
+      run: python setup.py sdist bdist_wheel
+
+    - name: Check built packages
+      run: twine check dist/*
+
+    - name: Build NPM package
+      run: cd dist && npm pack ..
+
+    - name: Hash Distributions
+      run: cd dist && sha256sum * | tee SHA256SUMS
+
+    - name: Upload Distributions
+      uses: actions/upload-artifact@v2
+      with:
+        name: jupyterlab_robotmode dist ${{ github.run_number }}
+        path: ./dist
 
     - name: Install jupyterlab_robotmode
       run: python -m pip install -e . --no-build-isolation --no-deps
@@ -51,11 +70,51 @@ jobs:
     - name: Run frontend unit tests
       run: jlpm test
 
+  test:
+    needs: [build]
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os: [ubuntu, windows, macos]
+        python-version: [3.6, 3.9]
+        include:
+        - python-version: 3.6
+          dist: jupyterlab_robotmode*.tar.gz
+        - python-version: 3.9
+          dist: jupyterlab_robotmode*.whl
+
+    steps:
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Download Distributions
+      uses: actions/download-artifact@v2
+      with:
+        name: jupyterlab_robotmode dist ${{ github.run_number }}
+        path: ./dist
+
+    - name: Install Distribution
+      run: |
+        set -eux
+        cd dist
+        pip install -v ${{ matrix.dist }}
+
+    - name: Get sys.prefix
+      id: sys-prefix
+      shell: bash -l {0}
+      run: |
+        set -eux
+        echo "::set-output name=path::python -c 'import sys; print(sys.prefix)'"
+
     - name: Check installation files
       run: |
-        test -d $CONDA_PREFIX/share/jupyter/labextensions/@marketsquare/jupyterlab_robotmode
-        test -f $CONDA_PREFIX/share/jupyter/labextensions/@marketsquare/jupyterlab_robotmode/package.json
+        set -eux
+        test -d ${{ steps.sys-prefix.outputs.path }}/share/jupyter/labextensions/@marketsquare/jupyterlab_robotmode
+        test -f ${{ steps.sys-prefix.outputs.path }}/share/jupyter/labextensions/@marketsquare/jupyterlab_robotmode/package.json
 
     - name: Check labextension
       run: |
+        set -eux
         jupyter labextension list 2>&1 | grep -ie "@marketsquare/jupyterlab_robotmode.*enabled.*ok" -

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,45 +2,51 @@ name: Tests
 
 on:
   push:
-    branches:
-    - main
+    branches: [main]
   pull_request:
-    branches:
-    - main
+    branches: [main]
 
 defaults:
   run:
     shell: bash -l {0}
 
+env:
+  CACHE_EPOCH: 0
+  BINDER_ENV: .binder/environment.yml
+
 jobs:
   run:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.9]
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup conda
-      uses: conda-incubator/setup-miniconda@v2
+    - name: Cache conda
+      uses: actions/cache@v1
       with:
-        activate-environment: default
-        environment-file: environment.yml
-        python-version: ${{ matrix.python-version }}
-        mamba-version: "*"
-        auto-activate-base: false
-        channels: conda-forge
+        path: ~/conda_pkgs_dir
+        key: |
+          ${{ env.CACHE_EPOCH }}-${{ runner.os }}-conda-${{ hashFiles(env.BINDER_ENV) }}
+        restore-keys:
+          ${{ env.CACHE_EPOCH }}-${{ runner.os }}-conda-
 
-    - name: Mamba install dependencies
-      run: mamba install python=${{ matrix.python-version }} pip nodejs jupyterlab=3 jupyter-packaging
+    - name: Cache JS
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: |
+          ${{ env.CACHE_EPOCH }}-node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+    - name: Setup conda
+      uses: conda-incubator/setup-miniconda@master  # TODO: revert to @v2 when miniforge available
+      with:
+        environment-file: ${{ env.BINDER_ENV }}
+        miniconda-variant: Mambaforge
+        use-only-tar-bz2: true
 
     - name: Install jupyterlab_robotmode
-      run: pip install -e .
+      run: python -m pip install -e . --no-build-isolation --no-deps
 
     - name: Run frontend unit tests
       run: jlpm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
         path: ./dist
 
     - name: Install jupyterlab_robotmode
-      run: python -m pip install -e . --no-build-isolation --no-deps
+      run: python -m pip install -e . --no-build-isolation --no-deps --install-option="--skip-npm"
 
     - name: Run frontend unit tests
       run: jlpm test
@@ -106,7 +106,7 @@ jobs:
       shell: bash -l {0}
       run: |
         set -eux
-        echo "::set-output name=path::python -c 'import sys; print(sys.prefix)'"
+        echo "::set-output name=path::$(python -c 'import sys; print(sys.prefix)')"
 
     - name: Check installation files
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
+*.egg-info
+coverage
+jupyterlab_robotmode/labextension
 lib
 node_modules
-jupyterlab_robotmode/labextension
-coverage

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # MarketSquare jupyterlab_robotmode
 
-A JupyterLab extensions which adds CodeMirror mode for Robot Framework syntax
+[![binder-badge]][binder] [![pypi-badge]][pypi] [![conda-badge]][conda] [![npm-badge]][npm]
 
+A JupyterLab extensions which adds CodeMirror mode for Robot Framework syntax
 
 ## Prerequisites
 
@@ -26,3 +27,12 @@ conda install jupyterlab_robotmode -c conda-forge
 ```bash
 jupyter labextension install @marketsquare/jupyterlab_robotmode
 ```
+
+[binder-badge]: https://mybinder.org/badge_logo.svg
+[binder]: https://mybinder.org/v2/gh/MarketSquare/jupyterlab_robotmode/HEAD?urlpath=lab
+[pypi]: https://pypi.org/project/jupyterlab-robotmode
+[pypi-badge]: https://img.shields.io/pypi/v/jupyterlab_robotmode
+[npm-badge]: https://img.shields.io/npm/v/@marketsquare/jupyterlab_robotmode
+[npm]: https://www.npmjs.com/package/@marketsquare/jupyterlab_robotmode
+[conda-badge]: https://img.shields.io/conda/vn/conda-forge/jupyterlab_robotmode
+[conda]: https://anaconda.org/conda-forge/jupyterlab_robotmode

--- a/yarn.lock
+++ b/yarn.lock
@@ -6592,15 +6592,15 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
-  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
-
 typescript@~4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
   integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+
+typescript@~4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 typestyle@^2.0.4:
   version "2.1.0"


### PR DESCRIPTION
As there were a lot of fiddly commits, feel free to squash merge all this trash, if it seems reasonable.

- [x] split build/test
- [x] test on win/linux/mac x 3.6/3.9
- [x] add badges to README
- [x] use mambaforge from `setup-miniconda@master` 
- [x] CI caching
- [x] adds binder (original intent... not much to see until we have  #7)