### PR TITLE
Use just `python` as python executable on macOS (python3 defaults to …

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        os: [ubuntu, windows, macos]
+        os: [ubuntu, windows, macos-latest]
         python-version: ['3.7', '3.10']
         lab-version: ['3']
         include:
@@ -86,7 +86,7 @@ jobs:
             dist: jupyterlab_robotmode*.whl
           - os: windows
             py-cmd: python
-          - os: macos
+          - os: macos-latest
             py-cmd: python
           - os: ubuntu
             py-cmd: python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
           - os: windows
             py-cmd: python
           - os: macos
-            py-cmd: python3
+            py-cmd: python
           - os: ubuntu
             py-cmd: python
 


### PR DESCRIPTION
…3.10 on GH actions)

Currently on `main` our macos python 3.7 CI is by accident running the tests with python 3.10 which causes them to fail. This PR is meant to fix this CI bug.